### PR TITLE
Use https URL for image to fix content warnings

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@ Updated 1.16.17 (xcode, here, and github) -->
 		
 		<br><br>
 		
-		<img src="http://i.imgur.com/Ox1i1j4.jpg" alt="A Staring at Phones Project" style="width:100%; max-width: 550px; padding-botton: 36%;" onclick = "window.open('http://staringatphones.com')">
+		<img src="//i.imgur.com/Ox1i1j4.jpg" alt="A Staring at Phones Project" style="width:100%; max-width: 550px; padding-botton: 36%;" onclick = "window.open('http://staringatphones.com')">
 		
 		<br><br>
 		


### PR DESCRIPTION
To fix [content warnings][1], where the page is requested over HTTPS but
assets are retrieved (insecurely) over HTTP, use an HTTPS URL for the
image of the snazzy dude staring at his phone.

[1]: https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content/How_to_fix_website_with_mixed_content